### PR TITLE
Add an installable vermeerkat script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@ RATT/RARG MeerKAT continuum self-calibration pipeline.
 ### Download and image observations in the last 3 days
 
 ```bash
-python -m vermeerat
+vermeerkat
 ```
 
 
 ### Specify a different configuration file
 
 ```bash
-python -m vermeerat -c myconfig.conf
+vermeerkat -c myconfig.conf
 ```
 
 ### Download and image a specific observation file, using a custom configuration file
 
 
 ```bash
-python -m vermeerkat -f 123456789.h5 -c myconfig.conf
+vermeerkat -f 123456789.h5 -c myconfig.conf
 ```
 
 ### The Astronomer, by Vermeer

--- a/setup.py
+++ b/setup.py
@@ -85,4 +85,5 @@ setup(name=PACKAGE_NAME,
     ],
     package_data={ PACKAGE_NAME: 'conf/*.conf' },
     include_package_data=True,
+    scripts=[os.path.join(PACKAGE_NAME, 'bin', 'vermeerkat')],
     zip_safe=False)

--- a/vermeerkat/bin/vermeerkat
+++ b/vermeerkat/bin/vermeerkat
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import sys
+import vermeerkat
+
+vermeerkat.run(sys.argv[1:])


### PR DESCRIPTION
```bash
vermeerkat <args>
```

is better than

```bash
python -m vermeerkat <args>
```